### PR TITLE
Load shedding implementation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,3 @@
 use Mix.Config
 
-config :ex_unit,
-  assert_receive_timeout: 800,
-  refute_receive_timeout: 200
+import_config "#{Mix.env}*.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,6 +8,7 @@ config :airbax,
   project_id:  "project_id",
   project_key: "project_key",
   environment: "test",
-  enabled:      true,
-  url:         "http://localhost:4004"
+  enabled:     true,
+  url:         "http://localhost:4004",
+  overload_threshold: 100
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,13 @@
+use Mix.Config
+
+config :ex_unit,
+  assert_receive_timeout: 800,
+  refute_receive_timeout: 200
+
+config :airbax,
+  project_id:  "project_id",
+  project_key: "project_key",
+  environment: "test",
+  enabled:      true,
+  url:         "http://localhost:4004"
+

--- a/lib/airbax.ex
+++ b/lib/airbax.ex
@@ -18,9 +18,9 @@ defmodule Airbax do
 
   @doc false
   def start(_type, _args) do
-    import Supervisor.Spec
-    children = [ worker(Airbax.Client, []) ]
-    Supervisor.start_link(children, strategy: :one_for_one)
+    # sidejob starts them under it's own supervisor
+    {:ok, _pid} = Airbax.Client.start_sidejob_resource()
+    Supervisor.start_link([], strategy: :one_for_one)
   end
 
   @doc """

--- a/lib/airbax.ex
+++ b/lib/airbax.ex
@@ -19,18 +19,7 @@ defmodule Airbax do
   @doc false
   def start(_type, _args) do
     import Supervisor.Spec
-
-    enabled = get_config(:enabled, true)
-
-    project_key = fetch_config(:project_key)
-    project_id = fetch_config(:project_id)
-    envt  = fetch_config(:environment)
-    url = get_config(:url, Airbax.Client.default_url)
-
-    children = [
-      worker(Airbax.Client, [project_key, project_id, envt, enabled, url])
-    ]
-
+    children = [ worker(Airbax.Client, []) ]
     Supervisor.start_link(children, strategy: :one_for_one)
   end
 
@@ -101,15 +90,4 @@ defmodule Airbax do
     Airbax.Client.emit(:error, body, params, session)
   end
 
-  defp get_config(key, default) do
-    Application.get_env(:airbax, key, default)
-  end
-
-  defp fetch_config(key) do
-    case get_config(key, :not_found) do
-      :not_found ->
-        raise ArgumentError, "the configuration parameter #{inspect(key)} is not set"
-      value -> value
-    end
-  end
 end

--- a/lib/airbax/client.ex
+++ b/lib/airbax/client.ex
@@ -17,7 +17,8 @@ defmodule Airbax.Client do
   @headers [{"content-type", "application/json"}]
 
   defmodule Regname do
-    # this module is needed because it'll be "rewritten" by sidejob
+    # this module is needed because a module that is
+    # used as a name is then "populated" by the sidejob
   end
 
   ## GenServer state

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,6 @@ defmodule Airbax.Mixfile do
      description: description(),
      package: package(),
      deps: deps(),
-     aliases: [test: "test --no-start"],
      name: "Airbax",
      docs: [main: "Airbax",
             source_ref: "v#{@version}",

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule Airbax.Mixfile do
      description: description(),
      package: package(),
      deps: deps(),
+     aliases: [test: "test --no-start"],
      name: "Airbax",
      docs: [main: "Airbax",
             source_ref: "v#{@version}",
@@ -20,13 +21,14 @@ defmodule Airbax.Mixfile do
   end
 
   def application() do
-    [applications: [:logger, :hackney, :poison],
+    [applications: [:logger, :hackney, :poison, :sidejob],
      mod: {Airbax, []}]
   end
 
   defp deps() do
     [{:hackney, "~> 1.1"},
      {:poison,  "~> 1.4 or ~> 2.0"},
+     {:sidejob, "~> 2.0"},
 
      {:ex_doc, ">= 0.0.0", only: :docs},
      {:earmark, ">= 0.0.0", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -1,13 +1,14 @@
 %{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
-  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:certifi, "0.4.0", [hex: :certifi, optional: false]}]},
+  "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "plug": {:hex, :plug, "0.13.1", "a1b3bd841400471203ee413277e5cf13f8ca59215e61736f4b2f7def9ea98612", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}
+  "sidejob": {:hex, :sidejob, "2.0.0", "a76bbf3cfb3bdcbaab354a2099e805f7fff6e35305c74fecbf4d48c1f7642ab3", [:rebar], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []}}

--- a/test/airbax/client_test.exs
+++ b/test/airbax/client_test.exs
@@ -3,13 +3,6 @@ defmodule Airbax.ClientTest do
 
   alias Airbax.Client
 
-  setup_all do
-    {:ok, pid} = start_airbax_client()
-    on_exit(fn ->
-      ensure_airbax_client_down(pid)
-    end)
-  end
-
   setup do
     {:ok, _} = RollbarAPI.start(self())
     on_exit(&RollbarAPI.stop/0)
@@ -34,12 +27,17 @@ defmodule Airbax.ClientTest do
   end
 
   test "emit slow" do
-    :ok = Client.emit(:warn, %{},  %{sleep: 50}, %{})
-    :ok = Client.emit(:warn, %{},  %{}, %{})
-    {_, len} = Process.info(Process.whereis(Client), :message_queue_len)
-    assert len == 0
-    assert_receive {:api_request, _body}
-    assert_receive {:api_request, _body}
+    n = Application.fetch_env!(:airbax, :overload_threshold) * 10
+
+    sent = Enum.take_while(1..n, fn _ ->
+      :ok == Client.emit(:warn, %{},  %{sleep: 50}, %{})
+    end)
+
+    assert length(sent) < n
+
+    for _ <- sent do
+      assert_receive {:api_request, _body}
+    end
   end
 
   test "endpoint is down" do

--- a/test/airbax/client_test.exs
+++ b/test/airbax/client_test.exs
@@ -4,7 +4,7 @@ defmodule Airbax.ClientTest do
   alias Airbax.Client
 
   setup_all do
-    {:ok, pid} = start_airbax_client("project_key", "project_id", "test")
+    {:ok, pid} = start_airbax_client()
     on_exit(fn ->
       ensure_airbax_client_down(pid)
     end)
@@ -31,6 +31,15 @@ defmodule Airbax.ClientTest do
     for _ <- 1..60 do
       assert_receive {:api_request, _body}
     end
+  end
+
+  test "emit slow" do
+    :ok = Client.emit(:warn, %{},  %{sleep: 50}, %{})
+    :ok = Client.emit(:warn, %{},  %{}, %{})
+    {_, len} = Process.info(Process.whereis(Client), :message_queue_len)
+    assert len == 0
+    assert_receive {:api_request, _body}
+    assert_receive {:api_request, _body}
   end
 
   test "endpoint is down" do

--- a/test/airbax_test.exs
+++ b/test/airbax_test.exs
@@ -1,13 +1,6 @@
 defmodule AirbaxTest do
   use ExUnit.AirbaxCase
 
-  setup_all do
-    {:ok, pid} = start_airbax_client()
-    on_exit(fn ->
-      ensure_airbax_client_down(pid)
-    end)
-  end
-
   setup do
     {:ok, _} = RollbarAPI.start(self())
     on_exit(&RollbarAPI.stop/0)

--- a/test/airbax_test.exs
+++ b/test/airbax_test.exs
@@ -2,7 +2,7 @@ defmodule AirbaxTest do
   use ExUnit.AirbaxCase
 
   setup_all do
-    {:ok, pid} = start_airbax_client("project_key", "project_id", "test")
+    {:ok, pid} = start_airbax_client()
     on_exit(fn ->
       ensure_airbax_client_down(pid)
     end)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,4 @@
 Logger.configure(level: :info)
-Application.ensure_all_started(:hackney)
-Application.ensure_all_started(:sidejob)
 ExUnit.start()
 
 defmodule ExUnit.AirbaxCase do
@@ -46,8 +44,8 @@ defmodule RollbarAPI do
     :timer.sleep(30)
     send test, {:api_request, body}
 
-    body_json =Poison.decode!(body)
-    sleep_t = get_in(body_json, ["params", "sleep"])
+    body_json = Poison.decode!(body)
+    sleep_t   = get_in(body_json, ["params", "sleep"])
 
     if is_integer(sleep_t) && sleep_t > 0 do
       Process.sleep(sleep_t)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -12,17 +12,6 @@ defmodule ExUnit.AirbaxCase do
     end
   end
 
-  def start_airbax_client() do
-    Airbax.Client.start_link()
-  end
-
-  def ensure_airbax_client_down(pid) do
-    ref = Process.monitor(pid)
-    receive do
-      {:DOWN, ^ref, _, _, _} -> :ok
-    end
-  end
-
   def capture_log(fun) do
     ExUnit.CaptureIO.capture_io(:user, fn ->
       fun.()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,6 @@
 Logger.configure(level: :info)
 Application.ensure_all_started(:hackney)
+Application.ensure_all_started(:sidejob)
 ExUnit.start()
 
 defmodule ExUnit.AirbaxCase do
@@ -11,8 +12,8 @@ defmodule ExUnit.AirbaxCase do
     end
   end
 
-  def start_airbax_client(project_key, project_id, env) do
-    Airbax.Client.start_link(project_key, project_id, env, true, "http://localhost:4004")
+  def start_airbax_client() do
+    Airbax.Client.start_link()
   end
 
   def ensure_airbax_client_down(pid) do
@@ -56,7 +57,14 @@ defmodule RollbarAPI do
     :timer.sleep(30)
     send test, {:api_request, body}
 
-    if get_in(Poison.decode!(body), ["params", "return_error?"]) do
+    body_json =Poison.decode!(body)
+    sleep_t = get_in(body_json, ["params", "sleep"])
+
+    if is_integer(sleep_t) && sleep_t > 0 do
+      Process.sleep(sleep_t)
+    end
+
+    if get_in(body_json, ["params", "return_error?"]) do
       send_resp(conn, 400, ~s({"err": 1, "message": "that was a bad request"}))
     else
       send_resp(conn, 201, "{}")


### PR DESCRIPTION
based on `basho/sidejob`

- `:sidejob.cast` doesn't slow down a caller, while providing the load shedding. If a resource is overloaded `:overload` is returned.
- In this case `sidejob` starts as many workers as there are schedulers in a current BEAM instance.
- I've changed tests setup for 2 reasons: 
     1. `sidejob` has no way to pass arguments to a module
     2. It's better to test an actual app instead of a "special test setup"